### PR TITLE
Added missing filter function for neighbors

### DIFF
--- a/src/bittybuzz/bbzneighbors.c
+++ b/src/bittybuzz/bbzneighbors.c
@@ -67,6 +67,7 @@ static void add_neighborlike_fields(int16_t count) {
 
     // Add function fields
     bbztable_add_function(__BBZSTRID_foreach, bbzneighbors_foreach);
+    bbztable_add_function(__BBZSTRID_filter,  bbzneighbors_filter);
     bbztable_add_function(__BBZSTRID_map,     bbzneighbors_map);
     bbztable_add_function(__BBZSTRID_get,     bbzneighbors_get);
     bbztable_add_function(__BBZSTRID_reduce,  bbzneighbors_reduce);


### PR DESCRIPTION
The filter function was missing for the neighbors table. I've just added it to make it available in the buzz code